### PR TITLE
fixes #6, which reports the sandbox container is failed to start

### DIFF
--- a/browser_server/requirements.txt
+++ b/browser_server/requirements.txt
@@ -1,4 +1,4 @@
-browser-use[memory]>=0.1.47
+browser-use[memory]==0.1.47
 fastapi>=0.115.12
 pyobjtojson>=0.3
 uvicorn>=0.34.2


### PR DESCRIPTION
The sandbox-runtime container is compatible with only 0.1.x of browser_use only. This PR fixes the issue #6.
