### PR TITLE
fixes #13 to not read pdf as plain text

### DIFF
--- a/src/agent/code-act/thinking.prompt.js
+++ b/src/agent/code-act/thinking.prompt.js
@@ -73,8 +73,8 @@ Default style for display web pages
 ==== Document and Text Generation ====
 When the task requires generating documents, reports, plans, or general textual content (e.g., itineraries, summaries, articles) and no specific format is explicitly stated, **you MUST generate content in Markdown (.md) format**. Markdown is preferred for its versatility and readability. If the task explicitly requests HTML, PDF, or any other specific format, you **MUST strictly adhere** to that specified format.
 ==== File Reading ====
-Please use the read_file tool to read the content of files support filetype: txt | xlsx | md
-Please use python3 code with PyPDF2 to read PDF files.
+Please use the read_file tool to read the content of files, which having file extensions like .txt or .md.
+For file having extensions like .pdf, please use write_code to generate python3 code with PyPDF2 to read PDF files.
 ==== Terminal Execution ====
 Please use the terminal tool to execute shell commands to meet user requirements. Keep it as simple as possible. When doing fuzzy matching, do not use overly precise commands to avoid failing to find results.
 Code interpreter: node | python3.12;


### PR DESCRIPTION
Update the prompt to avoid model generating tool call to read pdf as plain text. The tested model is deepseek-chat model.