### PR TITLE
Fix/db sync in dev mode & Fix/closeContainer undefined when RUNTIME_TYPE is not 'local-docker' 

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -19,15 +19,18 @@ var port = normalizePort(process.env.PORT || '3000');
  * Create HTTP server.
  */
 
+var sync = require('../src/models/sync');
 var server = http.createServer(app.callback());
 
 /**
  * Listen on provided port, on all network interfaces.
  */
 
-server.listen(port);
-server.on('error', onError);
-server.on('listening', onListening);
+sync().then(() => {
+  server.listen(port);
+  server.on('error', onError);
+  server.on('listening', onListening);
+});
 
 /**
  * Normalize a port into a number, string, or false.

--- a/src/routers/agent/run.js
+++ b/src/routers/agent/run.js
@@ -25,6 +25,8 @@ if (RUNTIME_TYPE && RUNTIME_TYPE === 'local-docker') {
   closeContainer = async () => {
     console.log('本地不执行')
   }
+} else {
+  closeContainer = async () => {}
 }
 
 const activeAgents = new Map();


### PR DESCRIPTION
Problem1: When running in dev mode (pnpm run dev), sync.js is never called, leaving the database empty. All API calls fail with SQLITE_ERROR: no such table.

Root cause: sync.js is only called in main.js (Electron entry), not in bin/www (Node dev entry).

Fix: Call sync() in bin/www before server.listen() to ensure tables are created on startup.